### PR TITLE
fix install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,11 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='scrambledtext',
-    version='0.1',
-    author = 'Jonathan Bourne',
-    description='A library for creating synthetic corrupted OCR text using a markov process ',
+    name="scrambledtext",
+    version="0.1",
+    author="Jonathan Bourne",
+    description="A library for creating synthetic corrupted OCR text using a markov process ",
     packages=find_packages(),
     include_package_data=True,
-    package_data={'scrambledtext': ['corruption_distribs.json']},
-    install_requires=[
-        collections, re, random, math, json
-    ],
+    package_data={"scrambledtext": ["corruption_distribs.json"]},
 )


### PR DESCRIPTION
The `install_requires` line from `setup.py` prevents installing the scrambledtext library as indicated in the README with the following error:

> NameError: name 'collections' is not defined. Did you forget to import 'collections'?

This commit removes this line (I don't think it was needed anyway, inside were modules from the standard library?)